### PR TITLE
Only run cron-job once a week

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   schedule:
-    - cron: "* * * * 0"
+    - cron: "0 0 * * 0"
   push:
     branches: [ "master" ]
 
@@ -23,5 +23,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
           publish_dir: ./out


### PR DESCRIPTION
- Currently runs once a minute on Sunday, change to run once a week.
- Add the `BASE16_BOT_ACCESS` token. I checked and currently the repo doesn't have any secrets attached so this would be fixing that too.