### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/gallery
+* @tinted-theming/gallery

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base16 Gallery 
 
-https://tinted-theming.github.io/base16-gallery
+https://tinted-theming.github.io/tinted-gallery
 
 This gallery is a collection of base16 themes maintained by
 [tinted-theming](https://github.com/tinted-theming). The software

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Base16 Gallery 
 
-https://base16-project.github.io/base16-gallery
+https://tinted-theming.github.io/base16-gallery
 
 This gallery is a collection of base16 themes maintained by
-[base16-project](https://github.com/base16-project). The software
+[tinted-theming](https://github.com/tinted-theming). The software
 license of `build.sh` is CC0.

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,10 @@ rm -rf out
 mkdir out
 
 rm -rf base16-vim
-git clone --depth=1 https://github.com/base16-project/base16-vim
+git clone --depth=1 https://github.com/tinted-theming/base16-vim
 
 rm -rf base16-schemes
-git clone --depth=1 https://github.com/base16-project/base16-schemes
+git clone --depth=1 https://github.com/tinted-theming/base16-schemes
 
 export COLORSCHEMES=($(ls base16-schemes/ | grep yaml | sed 's/\..*$//'))
 

--- a/template.erb
+++ b/template.erb
@@ -58,7 +58,7 @@
       <div class="row">
         <h1 class="text-center">Base16 Gallery</h1>
         <p class="text-center">
-          This gallery is generated from <a href="https://github.com/base16-project/base16-vim">base16-project/base16-vim</a>.</p>
+          This gallery is generated from <a href="https://github.com/tinted-theming/base16-vim">tinted-theming/base16-vim</a>.</p>
       </div>
       <div class="row" id="gallery">
       <% colorschemes.each do |colorscheme| %>


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.