### PR TITLE
Fix exit code build bug and duplicate gallery color hashes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,12 +17,12 @@ for COLORSCHEME in ${COLORSCHEMES[@]}; do
   echo $COLORSCHEME
 
   vim -es -u NORC -N \
-    -c 'set termguicolors' \
-    -c 'set runtimepath+=base16-vim' \
-    -c 'syntax on' \
-    -c "colorscheme base16-$COLORSCHEME" \
-    -c 'TOhtml' \
-    -c 'wqall' \
+    -c 'silent! set termguicolors' \
+    -c 'silent! set runtimepath+=base16-vim' \
+    -c 'silent! syntax on' \
+    -c "silent! colorscheme base16-$COLORSCHEME" \
+    -c 'silent! TOhtml' \
+    -c 'silent! wqa!' \
     $0 > /dev/null 2>&1
 
   grep -Pzo '(?s)<style>.*</style>' $0.html \

--- a/template.erb
+++ b/template.erb
@@ -71,22 +71,22 @@
           <div class="pallete">
             <% require 'yaml' %>
             <% palette = YAML.load_file("schemes/base16/#{colorscheme}.yaml")['palette'] %>
-            <div title="#<%= palette['base00'] %>" style="background-color: #<%= palette['base00'] %>;"></div>
-            <div title="#<%= palette['base01'] %>" style="background-color: #<%= palette['base01'] %>;"></div>
-            <div title="#<%= palette['base02'] %>" style="background-color: #<%= palette['base02'] %>;"></div>
-            <div title="#<%= palette['base03'] %>" style="background-color: #<%= palette['base03'] %>;"></div>
-            <div title="#<%= palette['base04'] %>" style="background-color: #<%= palette['base04'] %>;"></div>
-            <div title="#<%= palette['base05'] %>" style="background-color: #<%= palette['base05'] %>;"></div>
-            <div title="#<%= palette['base06'] %>" style="background-color: #<%= palette['base06'] %>;"></div>
-            <div title="#<%= palette['base07'] %>" style="background-color: #<%= palette['base07'] %>;"></div>
-            <div title="#<%= palette['base08'] %>" style="background-color: #<%= palette['base08'] %>;"></div>
-            <div title="#<%= palette['base09'] %>" style="background-color: #<%= palette['base09'] %>;"></div>
-            <div title="#<%= palette['base0A'] %>" style="background-color: #<%= palette['base0A'] %>;"></div>
-            <div title="#<%= palette['base0B'] %>" style="background-color: #<%= palette['base0B'] %>;"></div>
-            <div title="#<%= palette['base0C'] %>" style="background-color: #<%= palette['base0C'] %>;"></div>
-            <div title="#<%= palette['base0D'] %>" style="background-color: #<%= palette['base0D'] %>;"></div>
-            <div title="#<%= palette['base0E'] %>" style="background-color: #<%= palette['base0E'] %>;"></div>
-            <div title="#<%= palette['base0F'] %>" style="background-color: #<%= palette['base0F'] %>;"></div>
+            <div title="<%= palette['base00'] %>" style="background-color: <%= palette['base00'] %>;"></div>
+            <div title="<%= palette['base01'] %>" style="background-color: <%= palette['base01'] %>;"></div>
+            <div title="<%= palette['base02'] %>" style="background-color: <%= palette['base02'] %>;"></div>
+            <div title="<%= palette['base03'] %>" style="background-color: <%= palette['base03'] %>;"></div>
+            <div title="<%= palette['base04'] %>" style="background-color: <%= palette['base04'] %>;"></div>
+            <div title="<%= palette['base05'] %>" style="background-color: <%= palette['base05'] %>;"></div>
+            <div title="<%= palette['base06'] %>" style="background-color: <%= palette['base06'] %>;"></div>
+            <div title="<%= palette['base07'] %>" style="background-color: <%= palette['base07'] %>;"></div>
+            <div title="<%= palette['base08'] %>" style="background-color: <%= palette['base08'] %>;"></div>
+            <div title="<%= palette['base09'] %>" style="background-color: <%= palette['base09'] %>;"></div>
+            <div title="<%= palette['base0A'] %>" style="background-color: <%= palette['base0A'] %>;"></div>
+            <div title="<%= palette['base0B'] %>" style="background-color: <%= palette['base0B'] %>;"></div>
+            <div title="<%= palette['base0C'] %>" style="background-color: <%= palette['base0C'] %>;"></div>
+            <div title="<%= palette['base0D'] %>" style="background-color: <%= palette['base0D'] %>;"></div>
+            <div title="<%= palette['base0E'] %>" style="background-color: <%= palette['base0E'] %>;"></div>
+            <div title="<%= palette['base0F'] %>" style="background-color: <%= palette['base0F'] %>;"></div>
           </div>
           <div class="title text-center">
             <%= colorscheme %>


### PR DESCRIPTION
- Schemes now include a hash, so the hash needed to be removed in the gallery. Related: https://github.com/tinted-theming/schemes/pull/34
- The `build.sh` file was giving an exit code of 1 with the `build.sh.html` file creation, even though the file is created as expected, so add vim `silent!` flags to silence this unnecessary exit code status