### PR TITLE
Fix broken build when installing deps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,11 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Vim and Ruby
-        run: sudo apt install -y ruby vim
-  
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Check Vim version
+        run: vim --version
+
       - name: Build
         run: bash build.sh
 


### PR DESCRIPTION
- Vim already exists so doesn't need to be installed
- Use action to install ruby

Build error this PR fixes is the following in the `Setup Vim and Ruby` step: 
```
Run sudo apt install -y ruby vim

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
ruby is already the newest version (1:3.0~exp1).
ruby set to manually installed.
The following additional packages will be installed:
  vim-common vim-runtime vim-tiny
Suggested packages:
  ctags vim-doc vim-scripts indent
The following packages will be upgraded:
  vim vim-common vim-runtime vim-tiny
[4](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:5) upgraded, 0 newly installed, 0 to remove and 33 not upgraded.
Need to get 93[5](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:6)2 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd[6](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:7)4 vim amd64 2:8.2.3995-1ubuntu2.20
Ign:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-tiny amd64 2:[8](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:9).2.3995-1ubuntu2.20
Ign:4 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-runtime all 2:8.2.3[9](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:10)95-1ubuntu2.20
Ign:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim amd64 2:8.2.3995-1ubuntu2.20
Ign:5 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-common all 2:8.2.3995-1ubuntu2.20
Ign:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-tiny amd64 2:8.2.3995-1ubuntu2.20
Ign:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-runtime all 2:8.2.3995-1ubuntu2.20
Ign:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 vim-common all 2:8.2.3995-1ubuntu2.20
Err:2 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 vim amd64 2:8.2.3995-1ubuntu2.20
  404  Not Found [IP: 52.252.163.49 80]
Err:3 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 vim-tiny amd64 2:8.2.3995-1ubuntu2.20
  404  Not Found [IP: 52.252.163.49 80]
Err:4 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 vim-runtime all 2:8.2.3995-1ubuntu2.20
  404  Not Found [IP: 52.252.163.49 80]
Err:5 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 vim-common all 2:8.2.3995-1ubuntu2.20
  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim_8.2.3995-1ubuntu2.20_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim-tiny_8.2.3995-1ubuntu2.20_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim-runtime_8.2.3995-1ubuntu2.20_all.deb  404  Not Found [IP: 52.252.163.49 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/v/vim/vim-common_8.2.3995-1ubuntu2.20_all.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code [10](https://github.com/tinted-theming/base16-gallery/actions/runs/12101336986/job/33749737681#step:3:11)0.
```