### PR TITLE
docs: Fixed heading typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Titned Gallery 
+# Tinted Gallery
 
 https://tinted-theming.github.io/tinted-gallery
 


### PR DESCRIPTION
Fixes a single typo in the main heading of the `README.md`, from **Titned Gallery** to **Tinted Gallery**.